### PR TITLE
fix: move to next condition if parsing fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dazn/kopytko-framework": "^3.0.0",
         "@dazn/kopytko-utils": "^2.6.0",
-        "compare-versions-roku": "^1.0.0",
+        "compare-versions-roku": "^1.0.1",
         "murmurhash-roku": "^1.0.0"
       },
       "devDependencies": {
@@ -612,9 +612,9 @@
       }
     },
     "node_modules/compare-versions-roku": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/compare-versions-roku/-/compare-versions-roku-1.0.0.tgz",
-      "integrity": "sha512-ijFa5DHCOjrIRpc7BQh7YL/Xm1GRxIeCl9yKoFvalgE30wvWmAZCMOOIPh1JOg7dPdbGoUr3nL3WNZQWMpmyiA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/compare-versions-roku/-/compare-versions-roku-1.0.1.tgz",
+      "integrity": "sha512-eW8pZ1Z4HPXX+gkqiC4aJWZVE/QkkygzZw4ei8hx003dQ0dQKnGqHuRymUG/2WBbGfUVz3XaRyUbhaCWrcDjZw==",
       "dependencies": {
         "@dazn/kopytko-utils": "^2.6.0"
       }
@@ -2909,9 +2909,9 @@
       }
     },
     "compare-versions-roku": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/compare-versions-roku/-/compare-versions-roku-1.0.0.tgz",
-      "integrity": "sha512-ijFa5DHCOjrIRpc7BQh7YL/Xm1GRxIeCl9yKoFvalgE30wvWmAZCMOOIPh1JOg7dPdbGoUr3nL3WNZQWMpmyiA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/compare-versions-roku/-/compare-versions-roku-1.0.1.tgz",
+      "integrity": "sha512-eW8pZ1Z4HPXX+gkqiC4aJWZVE/QkkygzZw4ei8hx003dQ0dQKnGqHuRymUG/2WBbGfUVz3XaRyUbhaCWrcDjZw==",
       "requires": {
         "@dazn/kopytko-utils": "^2.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@dazn/kopytko-framework": "^3.0.0",
     "@dazn/kopytko-utils": "^2.6.0",
-    "compare-versions-roku": "^1.0.0",
+    "compare-versions-roku": "^1.0.1",
     "murmurhash-roku": "^1.0.0"
   },
   "devDependencies": {

--- a/src/components/libs/featurevisor/FeaturevisorConditions.brs
+++ b/src/components/libs/featurevisor/FeaturevisorConditions.brs
@@ -18,7 +18,13 @@ function featurevisorAllConditionsAreMatched(condition as Object, context as Obj
       return conditions.count() = filtered.count()
     end if
 
-    if (conditions.doesExist("attribute")) then return m._conditionIsMatched(conditions, context)
+    if (conditions.doesExist("attribute"))
+      try
+        return m._conditionIsMatched(conditions, context)
+      catch _error
+        return false
+      end try
+    end if
 
     if (conditions.doesExist("and") AND getType(conditions["and"]) = "roArray")
       filtered = m._arrayUtils.filter(conditions["and"], function (item as Object, context as Object) as Boolean

--- a/src/components/libs/featurevisor/_tests/FeaturevisorInstance.test.brs
+++ b/src/components/libs/featurevisor/_tests/FeaturevisorInstance.test.brs
@@ -1115,6 +1115,52 @@ function TestSuite__FeaturevisorInstance() as Object
     ]
   end function)
 
+  it("should not fail because of improperly formatted sem version", function (_ts as Object) as Object
+    ' Given
+    datafile = {
+      schemaVersion: "1",
+      revision: "1.0",
+      features: [
+        {
+          key: "test",
+          bucketBy: "userId",
+          traffic: [
+            { key: "0", segments: ["desktop", "version_gt5"], percentage: 100000 },
+            { key: "1", segments: "mobile", percentage: 100000 },
+            { key: "2", segments: "*", percentage: 0 },
+          ],
+        },
+      ],
+      attributes: [],
+      segments: [
+        {
+          key: "desktop",
+          conditions: FormatJson([{ attribute: "deviceType", operator: "equals", value: "desktop" }]),
+        },
+        {
+          key: "mobile",
+          conditions: FormatJson([{ attribute: "deviceType", operator: "equals", value: "mobile" }]),
+        },
+        {
+          key: "version_gt5",
+          conditions: FormatJson([{ attribute: "version", operator: "semverGreaterThan", value: "5.0" }]),
+        },
+      ],
+    }
+
+    ' When
+    initialize({ datafile: datafile })
+
+    ' Then
+    return [
+      expect(isEnabled("test", { deviceType: "desktop", version: "1.2.3" })).toBeFalse(),
+      expect(isEnabled("test", { deviceType: "desktop", version: "5.5.0" })).toBeTrue(),
+      expect(isEnabled("test", { deviceType: "mobile", version: "1.2.3" })).toBeTrue(),
+      expect(isEnabled("test", { deviceType: "mobile", version: "7.0.A101.99gbm.lg" })).toBeTrue(),
+      expect(isEnabled("test", { deviceType: "tablet", version: "5.5.A101.99gbm.lg" })).toBeFalse(),
+    ]
+  end function)
+
   return ts
 end function
 

--- a/src/components/libs/featurevisor/_tests/FeaturevisorSegments.test.brs
+++ b/src/components/libs/featurevisor/_tests/FeaturevisorSegments.test.brs
@@ -74,6 +74,7 @@ function TestSuite__FeaturevisorSegments() as Object
       { key: "germanMobileUsers", segments: [{ "and": ["mobileUsers", "germany"] }] },
       { key: "germanNonMobileUsers", segments: [{ "and": ["germany", { "not": ["mobileUsers"] }] }] },
       { key: "notVersion5.5", segments: [{ "not": ["version_5.5"] }] },
+      { key: "improperSemver", segments: [{ "and": ["mobileUsers", { "not": ["version_5.5"] }] }] },
     ]
   end sub)
 
@@ -289,6 +290,27 @@ function TestSuite__FeaturevisorSegments() as Object
       expect(featurevisorAllGroupSegmentsAreMatched(group.segments, { version: 5.7 }, m.__datafileReader)).toBeTrue(),
       expect(featurevisorAllGroupSegmentsAreMatched(group.segments, { version: "5.5" }, m.__datafileReader)).toBeFalse(),
       expect(featurevisorAllGroupSegmentsAreMatched(group.segments, { version: 5.5 }, m.__datafileReader)).toBeFalse(),
+    ]
+  end function)
+
+  it("should omit segment with improperly formatted sem version", function (_ts as Object) as Object
+    ' Given
+    group = m.__arrayUtils.find(m.__groups, { key: "improperSemver" })
+
+    ' Then
+    return [
+      expect(featurevisorAllGroupSegmentsAreMatched(group.segments, {
+        deviceType: "mobile",
+        version: "asd",
+      }, m.__datafileReader)).toBeTrue(),
+      expect(featurevisorAllGroupSegmentsAreMatched(group.segments, {
+        deviceType: "mobile",
+        version: "5.5.A101.99gbm.lg",
+      }, m.__datafileReader)).toBeTrue(),
+      expect(featurevisorAllGroupSegmentsAreMatched(group.segments, {
+        deviceType: "unknown",
+        version: "5.5.A101.99gbm.lg",
+      }, m.__datafileReader)).toBeFalse(),
     ]
   end function)
 


### PR DESCRIPTION
If comparison fails for any reason it just should go to the next condition.