### PR TITLE
fix: non-existent property in context when checking in and noIn conditions

### DIFF
--- a/src/components/libs/featurevisor/FeaturevisorConditions.brs
+++ b/src/components/libs/featurevisor/FeaturevisorConditions.brs
@@ -74,14 +74,14 @@ function featurevisorAllConditionsAreMatched(condition as Object, context as Obj
         end if
   
         return dateInContext.asSeconds() > dateInCondition.asSeconds()
-      else if (getType(context[condition.attribute]) = "roString" AND getType(condition.value) = "roArray")
+      else if (getType(condition.value) = "roArray" AND context.doesExist(condition.attribute) AND (context[condition.attribute] = Invalid OR getType(context[condition.attribute]) = "roString" OR m._isNumber(context[condition.attribute])))
         if (condition["operator"] = "in")
           return m._arrayUtils.contains(condition.value, function (item as String, context as Object) as Boolean
-            return item = context.compareValue
+            return context.compareValue <> Invalid AND item.toStr() = context.compareValue.toStr()
           end function, { compareValue: context[condition.attribute] })
         else if (condition["operator"] = "notIn")
           return NOT m._arrayUtils.contains(condition.value, function (item as String, context as Object) as Boolean
-            return item = context.compareValue
+            return context.compareValue <> Invalid AND item.toStr() = context.compareValue.toStr()
           end function, { compareValue: context[condition.attribute] })
         end if
       else if (getType(context[condition.attribute]) = "roString" AND getType(condition.value) = "roString")

--- a/src/components/libs/featurevisor/_tests/FeaturevisorConditions.test.brs
+++ b/src/components/libs/featurevisor/_tests/FeaturevisorConditions.test.brs
@@ -151,6 +151,56 @@ function TestSuite__FeaturevisorConditions() as Object
 
   testEach([
     {
+      context: { continent: "europe" },
+      expected: false,
+      name: "should fail for one correct attribute and one missing attribute in context",
+    },
+    {
+      context: { continent: "asia" },
+      expected: false,
+      name: "should fail for one incorrect attribute and one missing attribute in context",
+    },
+    {
+      context: { continent: "europe", country: "nl" },
+      expected: true,
+      name: "should pass for both correct attributes in context",
+    },
+    {
+      context: { continent: "europe", country: "gb" },
+      expected: false,
+      name: "should fail for one incorrect attribute and one correct attribute in context",
+    },
+    {
+      context: { continent: "europe", country: ["a", "b"] },
+      expected: false,
+      name: "should fail for one incorrect attribute and one correct attribute in context",
+    },
+    {
+      context: { continent: "europe", country: 100 },
+      expected: true,
+      name: "should pass for one incorrect attribute (when it is a number) and one correct attribute in context",
+    },
+    {
+      context: { continent: "europe", country: Invalid },
+      expected: true,
+      name: "should pass for one incorrect attribute (when it is an invalid) and one correct attribute in context",
+    },
+  ], "combined condition equals and notIn - ${name}", function (_ts as Object, params as Object)
+    ' Given
+    conditions = [
+      { attribute: "continent", operator: "equals", value: "europe" },
+      { attribute: "country", operator: "notIn", value: ["gb"] },
+    ]
+
+    ' When
+    result = featurevisorAllConditionsAreMatched(conditions, params.context)
+
+    ' Then
+    return expect(result).toBe(params.expected)
+  end function)
+
+  testEach([
+    {
       conditions: { attribute: "browser_type", operator: "equals", value: "chrome" },
       context: { browser_type: "chrome" },
       name: "should match with exact single condition",


### PR DESCRIPTION
Applied following JavaScript SDK fixes:
https://github.com/featurevisor/featurevisor/pull/328
https://github.com/featurevisor/featurevisor/pull/335